### PR TITLE
Use https URL for grunt-phantomcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/anselmh/grunt-phantomcss.git"
+    "url": "https://github.com/anselmh/grunt-phantomcss.git"
   },
   "bugs": {
     "url": "https://github.com/anselmh/grunt-phantomcss/issues"


### PR DESCRIPTION
Consistent with other URLs. Works on networks that block SSH.
